### PR TITLE
Add SQL tip folder and migrations tip

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -229,7 +229,7 @@ https://github.com/hanmoi-choi/reek-emacs
 
     # good
 
-    assert_predicate @user, :valid? # on error: expected @user to be valid?
+    assert_predicate @user, :valid? # on error: expected @user to not be valid?
 
     assert_includes response['message'], 'must be a valid email' # on error: expected response['message'] to include 'must be a valid email`
 
@@ -239,6 +239,22 @@ https://github.com/hanmoi-choi/reek-emacs
 
     assert response['message'].include?('must be a valid email') # on error: expect false to be truthy
     ```
+
+- Use the negative variations of selector tests if you are testing that a selector is not present.
+  Using the positive form of these selector tests will always make Capybara wait
+  the default selector timeout time, and this includes using these with `assert_not`.
+
+    ```ruby
+
+    # good
+
+    assert page.has_no_content?('Submit') # immediately executes if 'Submit' is not found
+
+    # bad
+
+    assert_not page.has_content?('Submit') # always waits the default Capybara timeout time
+    ```
+
 
 ### System Tests
 

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -240,9 +240,9 @@ https://github.com/hanmoi-choi/reek-emacs
     assert response['message'].include?('must be a valid email') # on error: expect false to be truthy
     ```
 
-- Use the negative variations of selector tests if you are testing that a selector is not present.
-  Using the positive form of these selector tests will always make Capybara wait
-  the default selector timeout time, and this includes using these with `assert_not`.
+- Use the negative variations of Capybara matchers if you are testing that an element or selector is not present.
+  Using the positive form of these matchers will always make Capybara wait
+  the default matcher timeout time, and this includes using these with `assert_not`.
 
     ```ruby
 

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -255,11 +255,6 @@ https://github.com/hanmoi-choi/reek-emacs
     assert_not page.has_content?('Submit') # always waits the default Capybara timeout time
     ```
 
-
-<<<<<<< HEAD
-=======
-
->>>>>>> eada21b... add tip
 ### System Tests
 
 ##### Organization

--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -229,7 +229,7 @@ https://github.com/hanmoi-choi/reek-emacs
 
     # good
 
-    assert_predicate @user, :valid? # on error: expected @user to not be valid?
+    assert_predicate @user, :valid? # on error: expected @user to be valid?
 
     assert_includes response['message'], 'must be a valid email' # on error: expected response['message'] to include 'must be a valid email`
 
@@ -256,6 +256,10 @@ https://github.com/hanmoi-choi/reek-emacs
     ```
 
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> eada21b... add tip
 ### System Tests
 
 ##### Organization


### PR DESCRIPTION
Since we operate on very large databases and want to ensure minimal downtime, we should be writing our migrations to go with that. I have added a migration tip sourced from [here](https://www.braintreepayments.com/blog/safe-operations-for-high-volume-postgresql/) that has some useful tips for our migrations. 
