### PR TITLE
Do not check for a redundant `self` call

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -65,6 +65,9 @@ Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': '()'
     '%w': '()'
+Style/RedundantSelf:
+  Description: Don't use self where it's not needed.
+  Enabled: false
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true


### PR DESCRIPTION
I prefer to be explicit when using an internal method or variable. This
removes the check for a redundant `self` call.