### PR TITLE
Add cop for encouraging trailing comma in multiline hashes

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -69,3 +69,7 @@ Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.
   Enabled: true
   EnforcedStyle: single_quotes
+Style/TrailingCommaInHashLiteral:
+  Description: Use a trailing comma in multi-line hashes.
+  Enabled: true
+  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
The use of a trailing comma in multiline hashes should be encouraged, as it makes diffs smaller and more meaningful. 

Source for cop: 
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/TrailingCommaInHashLiteral