### PR TITLE
Add custom cop to detect potentially unsafe usage of default database columns

### DIFF
--- a/style/ruby/.rubocop.yml
+++ b/style/ruby/.rubocop.yml
@@ -1,5 +1,7 @@
 # https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/ruby.yml
 
+require:
+  - ./extensions/unsafe_migration.rb
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
@@ -90,4 +92,7 @@ Style/TernaryParentheses:
 Style/Documentation:
   Enabled: true
 Style/MutableConstant:
+  Enabled: true
+Migration/UnsafeMigration:
+  Description: Detects the usage of 'default' column values in database migrations
   Enabled: true

--- a/style/ruby/extensions/unsafe_migration.rb
+++ b/style/ruby/extensions/unsafe_migration.rb
@@ -3,51 +3,32 @@ module RuboCop
     module Migration
       class UnsafeMigration < Cop
         MSG = <<~HEREDOC
-          Please verify a default value is safe to apply in this instance.
-          Ask in #database / #devops
+          Please verify a default column value is safe to apply in this instance.
+          Adding default values to large tables in production can cause downtime.
         HEREDOC
-
-        # This matcher is meant to run against a child node of create_table
-        def_node_matcher :_create_table_with_default_column_value?, <<~PATTERN
-          (hash <$(pair (sym :default) !nil) ...>)
-        PATTERN
 
         def_node_matcher :add_column_default_option?, <<~PATTERN
           (send nil? :add_column _ _ _ (hash <$(pair (sym :default) !nil) ...>))
         PATTERN
 
-        def_node_matcher :create_table_with_block?, <<~PATTERN
-          (block
-            (send nil? :create_table ...)
-            (args (arg _var))
-            _)
+        def_node_matcher :change_column_default_option?, <<~PATTERN
+          (send nil? :change_column _ _ _ (hash <$(pair (sym :default) !nil) ...>))
         PATTERN
 
-        def create_table_with_default_column_value?(node)
-          return false unless node
-
-          if _create_table_with_default_column_value?(node)
-            return true
-          end
-
-          if node && node.respond_to?(:children) && node.children.any?
-            node.children.each do |child| 
-              if create_table_with_default_column_value?(child)
-                add_offense(child)
-              end
-            end
-          end
-
-          false
+        # Attempt to ignore 'down' methods
+        def up_or_change_method?(node)
+          return false unless node.parent && node.parent.parent
+          return true unless node.parent.parent.respond_to?(:method_name)
+          node.parent.parent.method_name == :up || node.parent.parent.method_name == :change
         end
 
         def on_send(node, *args)
-          if add_column_default_option?(node)
+          if add_column_default_option?(node) && up_or_change_method?(node)
             add_offense(node)
           end
 
-          if create_table_with_block?(node.parent)
-            create_table_with_default_column_value?(node.parent)
+          if change_column_default_option?(node) && up_or_change_method?(node)
+            add_offense(node)
           end
         end
       end

--- a/style/ruby/extensions/unsafe_migration.rb
+++ b/style/ruby/extensions/unsafe_migration.rb
@@ -1,0 +1,56 @@
+module RuboCop
+  module Cop
+    module Migration
+      class UnsafeMigration < Cop
+        MSG = <<~HEREDOC
+          Please verify a default value is safe to apply in this instance.
+          Ask in #database / #devops
+        HEREDOC
+
+        # This matcher is meant to run against a child node of create_table
+        def_node_matcher :_create_table_with_default_column_value?, <<~PATTERN
+          (hash <$(pair (sym :default) !nil) ...>)
+        PATTERN
+
+        def_node_matcher :add_column_default_option?, <<~PATTERN
+          (send nil? :add_column _ _ _ (hash <$(pair (sym :default) !nil) ...>))
+        PATTERN
+
+        def_node_matcher :create_table_with_block?, <<~PATTERN
+          (block
+            (send nil? :create_table ...)
+            (args (arg _var))
+            _)
+        PATTERN
+
+        def create_table_with_default_column_value?(node)
+          return false unless node
+
+          if _create_table_with_default_column_value?(node)
+            return true
+          end
+
+          if node && node.respond_to?(:children) && node.children.any?
+            node.children.each do |child| 
+              if create_table_with_default_column_value?(child)
+                add_offense(child)
+              end
+            end
+          end
+
+          false
+        end
+
+        def on_send(node, *args)
+          if add_column_default_option?(node)
+            add_offense(node)
+          end
+
+          if create_table_with_block?(node.parent)
+            create_table_with_default_column_value?(node.parent)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
How to run this cop by itself:
```
rubocop --only Migration/UnsafeMigration -c style/ruby/.rubocop.yml /path/to/db/migrate/2020*
```

Example output:
```
/Users/jamescook/work/archimedes/db/migrate/20200618191031_add_concurrency_limiter_fields_to_settings.rb:4:5: C: Migration/UnsafeMigration: Please verify a default column value is safe to apply in this instance.
Adding default values to large tables in production can cause downtime.

    add_column :settings, :auto_limiter_capacity, :integer, default: 2000
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/jamescook/work/archimedes/db/migrate/20200710142612_add_prevent_student_account_editing_to_institutions.rb:5:5: C: Migration/UnsafeMigration: Please verify a default column value is safe to apply in this instance.
Adding default values to large tables in production can cause downtime.

    add_column(:institutions, :prevent_student_account_editing, :boolean, default: false)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/jamescook/work/archimedes/db/migrate/20200803190412_add_visual_context_to_ml_presence_events.rb:12:7: C: Migration/UnsafeMigration: Please verify a default column value is safe to apply in this instance.
Adding default values to large tables in production can cause downtime.

      add_column(:ml_presence_events, :instances, :jsonb, null: false, default: '[]')
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/jamescook/work/archimedes/db/migrate/20200803190422_add_visual_context_to_ml_contraband_events.rb:12:7: C: Migration/UnsafeMigration: Please verify a default column value is safe to apply in this instance.
Adding default values to large tables in production can cause downtime.

      add_column(:ml_contraband_events, :instances, :jsonb, null: false, default: '[]')
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
